### PR TITLE
Add Basic DropCursor Support

### DIFF
--- a/example/src/Examples/ConfigureExtentions.tsx
+++ b/example/src/Examples/ConfigureExtentions.tsx
@@ -1,4 +1,3 @@
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React from 'react';
 import { SafeAreaView, View, StyleSheet, Button } from 'react-native';
 import {
@@ -8,12 +7,10 @@ import {
   TenTapStartKit,
   useEditorBridge,
 } from '@10play/tentap-editor';
+import { DropCursorBridge } from '../../../src/bridges/dropcursor';
 
-export const ConfigureExtensions = ({}: NativeStackScreenProps<
-  any,
-  any,
-  any
->) => {
+export const ConfigureExtensions = () => {
+  const [hideContent, setHideContent] = React.useState(false);
   const editor = useEditorBridge({
     autofocus: true,
     avoidIosKeyboard: true,
@@ -23,29 +20,33 @@ export const ConfigureExtensions = ({}: NativeStackScreenProps<
         placeholder: 'Hey there! Start typing...',
       }),
       LinkBridge.configureExtension({ openOnClick: false }),
+      DropCursorBridge.configureExtension({
+        color: '#84affe',
+        width: 2,
+      }),
     ],
   });
 
   return (
     <SafeAreaView style={exampleStyles.fullScreen}>
-      <View style={exampleStyles.fullScreen}>
-        <RichText editor={editor} />
-      </View>
-      <View style={exampleStyles.fullScreen}>
+      <View>
         <Button
-          title="Click Me To Add Link"
+          title="Toggle Content"
           onPress={() => {
             editor.setContent(
-              '<a href="https://10play.github.io/10tap-editor">Link To TenTap!</a>'
+              hideContent
+                ? ''
+                : `<a href="https://10play.github.io/10tap-editor">Link To TenTap!</a>
+            <p>Try to drag around the image. While you drag, the editor should show a decoration under your cursor. The so called dropcursor.</p></br>
+            <img src="https://source.unsplash.com/8xznAGy4HcY/800x400" /></br>
+            <p>Drag Me Here</p></br></br></br></br></br><p>Or Here</p>`
             );
+            setHideContent(!hideContent);
           }}
         />
-        <Button
-          title="Click Me To Show PlaceHolder"
-          onPress={() => {
-            editor.setContent('');
-          }}
-        />
+      </View>
+      <View style={exampleStyles.fullScreen}>
+        <RichText editor={editor} />
       </View>
     </SafeAreaView>
   );

--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
     "@tiptap/extension-code-block": "^2.2.1",
     "@tiptap/extension-color": "^2.1.16",
     "@tiptap/extension-document": "^2.2.1",
+    "@tiptap/extension-dropcursor": "^2.2.4",
     "@tiptap/extension-heading": "^2.2.1",
     "@tiptap/extension-highlight": "^2.1.16",
     "@tiptap/extension-history": "^2.2.1",

--- a/src/bridges/StarterKit.ts
+++ b/src/bridges/StarterKit.ts
@@ -16,6 +16,7 @@ import { HighlightBridge } from './highlight';
 import { CoreBridge } from './core';
 import { ImageBridge } from './image';
 import { PlaceholderBridge } from './placeholder';
+import { DropCursorBridge } from './dropcursor';
 
 export const TenTapStartKit = [
   BoldBridge,
@@ -36,4 +37,5 @@ export const TenTapStartKit = [
   CoreBridge,
   PlaceholderBridge,
   ListItemBridge,
+  DropCursorBridge,
 ];

--- a/src/bridges/dropcursor.ts
+++ b/src/bridges/dropcursor.ts
@@ -1,0 +1,6 @@
+import DropCursor from '@tiptap/extension-dropcursor';
+import BridgeExtension from './base';
+
+export const DropCursorBridge = new BridgeExtension({
+  tiptapExtension: DropCursor,
+});

--- a/website/docs/api/BridgeExtensions.md
+++ b/website/docs/api/BridgeExtensions.md
@@ -97,3 +97,8 @@ relevant configuration: https://tiptap.dev/docs/editor/api/marks/underline#setti
 
 uses `@tiptap/extension-placeholder`
 relevant configuration: https://tiptap.dev/docs/editor/api/extensions/placeholder#settings
+
+### DropCursorBridge
+
+uses `@tiptap/extension-dropcursor`
+relevant configuration: https://tiptap.dev/docs/editor/api/extensions/dropcursor#settings

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,7 @@ __metadata:
     "@tiptap/extension-code-block": ^2.2.1
     "@tiptap/extension-color": ^2.1.16
     "@tiptap/extension-document": ^2.2.1
+    "@tiptap/extension-dropcursor": ^2.2.4
     "@tiptap/extension-heading": ^2.2.1
     "@tiptap/extension-highlight": ^2.1.16
     "@tiptap/extension-history": ^2.2.1
@@ -4993,6 +4994,16 @@ __metadata:
     "@tiptap/core": ^2.0.0
     "@tiptap/pm": ^2.0.0
   checksum: 88d8b3ff12dc7d0c2ded3da6cece669f3c2bd8e1fb51553ed8374dba386ee7cf2db47a99318bb3e4cc43afb1509c5c77843675734239a4c54d4e3d0191a46c89
+  languageName: node
+  linkType: hard
+
+"@tiptap/extension-dropcursor@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "@tiptap/extension-dropcursor@npm:2.2.4"
+  peerDependencies:
+    "@tiptap/core": ^2.0.0
+    "@tiptap/pm": ^2.0.0
+  checksum: eccc125414abaad4e274bf15c41919b143924e3ea0a487c3f1133aa506faf97d4027cf9b0b6d721242cd3dabcdaf264cf3ea0015c2dc296380c903853e3b7e02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add support for https://tiptap.dev/docs/editor/api/extensions/dropcursor#settings #65 
Not to much in this bridge, as no messaging is needed, only thing exposed is configure which can be used with `configureExtension`

```tsx
DropCursorBridge.configureExtension({
    color: '#84affe',
    width: 2,
}),
```

https://github.com/10play/10tap-editor/assets/36531255/3c9a1d37-fada-4fb2-807c-c30ae62b078d

