### PR TITLE
Color Keyboard Pallete Override 

### DIFF
--- a/example/src/Examples/WithKeyboard.tsx
+++ b/example/src/Examples/WithKeyboard.tsx
@@ -35,7 +35,6 @@ export const WithKeyboard = ({}: NativeStackScreenProps<any, any, any>) => {
       * {
           font-family: 'Rubik', sans-serif;
       }
-
     `),
     ],
   });

--- a/src/RichText/Keyboard/ColorKeyboard.tsx
+++ b/src/RichText/Keyboard/ColorKeyboard.tsx
@@ -133,7 +133,9 @@ const ColorButton = ({
           source={Images.a}
           style={[
             theme?.colorKeyboard.textIcon,
-            { tintColor: color.value || theme?.colorKeyboard.defaultTextColor },
+            {
+              tintColor: color.displayColor || color.value,
+            },
           ]}
           resizeMode="contain"
         />
@@ -145,8 +147,7 @@ const ColorButton = ({
           style={[
             theme?.colorKeyboard.highlight,
             {
-              backgroundColor:
-                color.value || theme?.colorKeyboard.defaultHighlightColor,
+              backgroundColor: color.displayColor || color.value,
             },
           ]}
         />

--- a/src/RichText/Keyboard/keyboardTheme.ts
+++ b/src/RichText/Keyboard/keyboardTheme.ts
@@ -70,10 +70,10 @@ export const defaultColorKeyboardTheme: ColorKeyboardTheme = {
   bottomSpacer: {
     height: 30,
   },
-  defaultTextColor: '#898989',
   colorSelection: [
     {
       name: 'Default',
+      displayColor: '#898989',
       value: undefined,
     },
     {
@@ -109,11 +109,11 @@ export const defaultColorKeyboardTheme: ColorKeyboardTheme = {
       value: '#000000',
     },
   ],
-  defaultHighlightColor: '#8989894D',
   highlightSelection: [
     {
       name: 'Default',
       value: undefined,
+      displayColor: '#8989894D',
     },
     {
       name: 'Red',
@@ -172,10 +172,10 @@ export const darkColorKeyboardTheme: Partial<ColorKeyboardTheme> = {
   sectionTitle: {
     color: '#CACACA',
   },
-  defaultTextColor: 'white',
   colorSelection: [
     {
       name: 'Default',
+      displayColor: 'white',
       value: undefined,
     },
     {
@@ -211,10 +211,10 @@ export const darkColorKeyboardTheme: Partial<ColorKeyboardTheme> = {
       value: '#000000',
     },
   ],
-  defaultHighlightColor: '#E5E5E580',
   highlightSelection: [
     {
       name: 'Default',
+      displayColor: '#E5E5E580',
       value: undefined,
     },
     {

--- a/src/RichText/useEditorBridge.tsx
+++ b/src/RichText/useEditorBridge.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useRef } from 'react';
 import WebView from 'react-native-webview';
 import cloneDeep from 'lodash/cloneDeep';
-import merge from 'lodash/merge';
 import {
   type EditorActionMessage,
   EditorMessageType,
@@ -15,8 +14,9 @@ import { uniqueBy } from '../utils';
 import { defaultEditorTheme } from './theme';
 import type { Subscription } from '../types/Subscription';
 import { getStyleSheetCSS } from './utils';
+import { mergeThemes } from '../utils/mergeThemes';
 
-type RecursivePartial<T> = {
+export type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
@@ -45,7 +45,7 @@ export const useEditorBridge = (options?: {
 
   const mergedTheme = useMemo(
     // We must deep clone defaultEditorTheme, because it is read only
-    () => merge(cloneDeep(defaultEditorTheme), options?.theme),
+    () => mergeThemes(cloneDeep(defaultEditorTheme), options?.theme),
     [options?.theme]
   );
 

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -37,8 +37,9 @@ export type LinkBarTheme = {
 };
 
 export interface Color {
-  value?: ColorValue;
   name: string;
+  value?: ColorValue;
+  displayColor?: ColorValue;
 }
 export type ColorKeyboardTheme = {
   scrollViewContainer: StyleProp<ViewStyle>;
@@ -54,7 +55,5 @@ export type ColorKeyboardTheme = {
   bottomSpacer: StyleProp<ViewStyle>;
   colorSelection: Color[];
   highlightSelection: Color[];
-  defaultTextColor: ColorValue;
-  defaultHighlightColor: ColorValue;
   keyboardRootColor: ColorValue;
 };

--- a/src/utils/mergeThemes.ts
+++ b/src/utils/mergeThemes.ts
@@ -1,0 +1,22 @@
+import merge from 'lodash/merge';
+import type { Color, EditorTheme } from '../types';
+import type { RecursivePartial } from '../RichText';
+
+export const mergeThemes = (
+  theme1: EditorTheme,
+  theme2: RecursivePartial<EditorTheme> | undefined
+) => {
+  const merged = merge(theme1, theme2);
+
+  const colorModified = !!theme2?.colorKeyboard?.colorSelection;
+  const highlightModified = !!theme2?.colorKeyboard?.highlightSelection;
+  // We have a special case with colorKeyboard, where if set we do not want default values
+  if (colorModified)
+    merged.colorKeyboard.colorSelection = theme2.colorKeyboard!
+      .colorSelection as Color[];
+  if (highlightModified)
+    merged.colorKeyboard.highlightSelection = theme2.colorKeyboard!
+      .highlightSelection as Color[];
+
+  return merged;
+};

--- a/website/docs/examples/customTheme.md
+++ b/website/docs/examples/customTheme.md
@@ -28,6 +28,7 @@ useEditorBridge({
         {
           name: 'Custom Color',
           value: '#E5112B',
+          displayColor: '#E5112B', // Optional - the color that will be displayed on ui (if left empty will default to use value)
         },
       ],
       // Check KeyboardTheme type for all options


### PR DESCRIPTION
Fix a bug where default colors are added to color keyboard even when overridden, and add a way to use attributes instead of a actual colors. #68