### PR TITLE
Fix Codegen Issue with RN 0.73.5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
       "import": "./lib-web/index.mjs",
       "require": "./lib-web/index.umd.cjs",
       "types": "./lib-web/typescript/webEditorUtils/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "source": "src/index",
   "files": [


### PR DESCRIPTION
Fix issue where codegen fails to find tentap, because 
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" 
```
https://github.com/10play/10tap-editor/issues/82 