### PR TITLE
Add Editable Prop

### DIFF
--- a/src/RichText/RichText.tsx
+++ b/src/RichText/RichText.tsx
@@ -137,7 +137,9 @@ export const RichText = ({ editor, ...props }: RichTextProps) => {
           editor.initialContent
             ? `window.initialContent = '${editor.initialContent}';`
             : ''
-        }`}
+        }
+          window.editable = ${editor.editable};
+        `}
         hideKeyboardAccessoryView={true}
         onMessage={onWebviewMessage}
         ref={editor.webviewRef}

--- a/src/RichText/useEditorBridge.tsx
+++ b/src/RichText/useEditorBridge.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import WebView from 'react-native-webview';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -29,6 +29,7 @@ export const useEditorBridge = (options?: {
   avoidIosKeyboard?: boolean;
   customSource?: string;
   webviewBaseURL?: string;
+  editable?: boolean;
   onChange?: () => void;
   DEV?: boolean;
   DEV_SERVER_URL?: string;
@@ -51,6 +52,15 @@ export const useEditorBridge = (options?: {
     () => mergeThemes(cloneDeep(defaultEditorTheme), options?.theme),
     [options?.theme]
   );
+
+  const editable = options?.editable === undefined ? true : options.editable;
+  useEffect(() => {
+    if (options) {
+      // Special case for editable prop, since its command is on the core bridge and we want to access it via useEditorBridge
+      editorInstance?.setEditable(editable);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editable]);
 
   const _updateEditorState = (editorState: BridgeState) => {
     editorStateRef.current = editorState;
@@ -119,6 +129,7 @@ export const useEditorBridge = (options?: {
     autofocus: options?.autofocus,
     avoidIosKeyboard: options?.avoidIosKeyboard,
     customSource: options?.customSource,
+    editable,
     webviewBaseURL: options?.webviewBaseURL,
     DEV_SERVER_URL: options?.DEV_SERVER_URL,
     DEV: options?.DEV,

--- a/src/types/EditorBridge.ts
+++ b/src/types/EditorBridge.ts
@@ -14,6 +14,7 @@ export interface EditorBridge {
   autofocus: boolean;
   focus: (pos?: 'start' | 'end' | 'all' | number | boolean | null) => void;
   initialContent?: string;
+  editable?: boolean;
   webviewRef: RefObject<WebView>;
   getEditorState: () => BridgeState;
   _updateEditorState: (state: BridgeState) => void;

--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -10,6 +10,7 @@ import { blueBackgroundPlugin } from '../bridges/HighlightSelection';
 declare global {
   interface Window {
     initialContent: string;
+    editable: string;
     bridgeExtensionConfigMap: string;
     whiteListBridgeExtensions: string[];
     ReactNativeWebView: { postMessage: (message: string) => void };
@@ -89,6 +90,7 @@ export const useTenTap = (options?: useTenTapArgs) => {
     },
     onSelectionUpdate: (onUpdate) => sendStateUpdate(onUpdate.editor),
     onTransaction: (onUpdate) => sendStateUpdate(onUpdate.editor),
+    editable: window.editable,
     ...tiptapOptionsWithExtensions,
   });
 

--- a/website/docs/api/BridgeState.md
+++ b/website/docs/api/BridgeState.md
@@ -10,6 +10,11 @@ The list above is the interface of BridgeState in case you use `TenTapStarterkit
 
 ### BridgeState properties
 
+#### editable
+
+`boolean`
+<br />Is the editor editable or not <br /> extended by [CoreBridge](./BridgeExtensions#coreextension)
+
 #### selection
 
 `{ from: number; to: number }`

--- a/website/docs/api/EditorBridge.md
+++ b/website/docs/api/EditorBridge.md
@@ -45,6 +45,11 @@ an async function that will return the content of the editor in json format <br 
 `(content: string) => void`<br />
 a function that get's html as string and set set's it as the editors content <br /> extended by [CoreBridge](./BridgeExtensions#coreextension)
 
+#### setEditable
+
+`(editable: boolean) => void`<br />
+a function that sets the editable state <br /> extended by [CoreBridge](./BridgeExtensions#coreextension)
+
 #### setSelection
 
 `(from: number, to: number) => void`<br />

--- a/website/docs/api/useEditorBridge.md
+++ b/website/docs/api/useEditorBridge.md
@@ -36,6 +36,12 @@ This helps us keep the cursor right above the keyboard when the editor is full-s
 <u>default</u>: `defaultEditorTheme` <i>(light theme)</i><br />
 this prop can be used to customize default styles, see [theme example](../examples/customTheme.md)
 
+#### editable
+
+`boolean`
+<u>default</u>: `true`<br />
+When set to false the editor will be `readonly`
+
 #### customSource
 
 `string`  


### PR DESCRIPTION
Add `editable` prop to `useEditorBridge`, in addition add `setEditable` to core extension. #93

By default editable is set to true


https://github.com/10play/10tap-editor/assets/36531255/b5701572-2b56-4248-94b8-53f5d73be5f1

