### PR TITLE
Lift/Sink Task List Item

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1124,7 +1124,7 @@ PODS:
   - RNSVG (14.1.0):
     - React-Core
   - SocketRocket (0.6.1)
-  - tentap (0.4.48):
+  - tentap (0.5.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1400,7 +1400,7 @@ SPEC CHECKSUMS:
   RNScreens: 17e2f657f1b09a71ec3c821368a04acbb7ebcb46
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  tentap: 0f954874f4c976e66198453369308bb0c91b5b77
+  tentap: cd55c8d991abd94603ec17e5304b62a1e36a4cf0
   Yoga: 9e6a04eacbd94f97d94577017e9f23b3ab41cf6c
 
 PODFILE CHECKSUM: 59f02bbde682eb22b765a58d4a0ce59d95964282

--- a/src/RichText/Toolbar/actions.ts
+++ b/src/RichText/Toolbar/actions.ts
@@ -142,6 +142,8 @@ export const DEFAULT_TOOLBAR_ITEMS: ToolbarItem[] = [
     image: () => Images.bulletList,
   },
   {
+    // Regular list items (li) and task list items both use the
+    // same sink command and button just with a different parameter, so we check both states here
     onPress:
       ({ editor, editorState }) =>
       () =>
@@ -152,6 +154,8 @@ export const DEFAULT_TOOLBAR_ITEMS: ToolbarItem[] = [
     image: () => Images.indent,
   },
   {
+    // Regular list items (li) and task list items both use the
+    // same lift command and button just with a different parameter, so we check both states here
     onPress:
       ({ editor, editorState }) =>
       () =>

--- a/src/RichText/Toolbar/actions.ts
+++ b/src/RichText/Toolbar/actions.ts
@@ -143,20 +143,22 @@ export const DEFAULT_TOOLBAR_ITEMS: ToolbarItem[] = [
   },
   {
     onPress:
-      ({ editor }) =>
+      ({ editor, editorState }) =>
       () =>
-        editor.sink(),
+        editorState.canSink ? editor.sink() : editor.sinkTaskListItem(),
     active: () => false,
-    disabled: ({ editorState }) => !editorState.canSink,
+    disabled: ({ editorState }) =>
+      !editorState.canSink && !editorState.canSinkTaskListItem,
     image: () => Images.indent,
   },
   {
     onPress:
-      ({ editor }) =>
+      ({ editor, editorState }) =>
       () =>
-        editor.lift(),
+        editorState.canLift ? editor.lift() : editor.liftTaskListItem(),
     active: () => false,
-    disabled: ({ editorState }) => !editorState.canLift,
+    disabled: ({ editorState }) =>
+      !editorState.canLift && !editorState.canLiftTaskListItem,
     image: () => Images.outdent,
   },
   {


### PR DESCRIPTION
Set `nested: true` by default on task list item extension. I think ideally we should add a way to configure extension dependancies, but for now this might be enough.

https://github.com/10play/10tap-editor/assets/36531255/db0cd26b-7e62-4dff-aa2a-496cc4dae8b2

## TODO

Need to test expo, to make sure configure in bridge does not cause any problems