### PR TITLE
Fix android focus and dynamic height

### DIFF
--- a/src/bridges/core.ts
+++ b/src/bridges/core.ts
@@ -305,7 +305,11 @@ export const CoreBridge = new BridgeExtension<
         return json;
       },
       focus: (pos: FocusArgs) => {
-        webviewRef?.current?.requestFocus();
+        setTimeout(() => {
+          webviewRef?.current?.requestFocus();
+          // Adding this for android, there is a race where the focus is not set if it's too close to Load
+          // https://github.com/react-native-webview/react-native-webview/issues/1172
+        }, 100);
         if (editorStateRef && editorStateRef.current) {
           _updateEditorState &&
             _updateEditorState({


### PR DESCRIPTION
1/10 times the editor autofocus not working on android, I added a really hacky fix (adding 100ms timeout before requestfocus) for it as detailed here:
https://github.com/react-native-webview/react-native-webview/issues/1172

In top of the TextInput hack for open the keyboard

I also use avoidIosKeyboard for android as well so when not true (mostly when using the editor not with fullsize) we wouldnt add bottom padding, we will change `avoidIosKeyboard` -> `avoidKeyboard` in v1.0.0