### PR TITLE
fix: issue with decorations on advanced setup

### DIFF
--- a/src/webEditorUtils/vite.config.ts
+++ b/src/webEditorUtils/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['react'],
+      external: ['@tiptap/pm/view', 'react', 'react/jsx-runtime', 'react-dom'],
       output: {
         dir: 'lib-web',
         // Provide global variables to use in the UMD build


### PR DESCRIPTION
When using advanced setup and trying to work with decorations we see that error:
```
undefined is not an object (evaluating 'this.members[i].localsInner')
```

After a lot of investigations it looks like rollup/vite might bundle prosemirror-view inside the web-utils bundle what can cause double instances of prosemirror-view, thanks to:
https://github.com/ueberdosis/tiptap/issues/3869#issuecomment-2167931620

I managed to external @tiptap/pm/view from web-utils and it solve the issues with decorations