### PR TITLE
fix: android crash on first mount

### DIFF
--- a/example/src/Examples/Advanced/editor-web/index.tsx
+++ b/example/src/Examples/Advanced/editor-web/index.tsx
@@ -5,6 +5,25 @@ import { AdvancedEditor } from './AdvancedEditor';
 /**
  * This is the entrypoint for the "web" part of our editor that will be built with vite
  */
-const container = document.getElementById('root');
-const root = createRoot(container!);
-root.render(<AdvancedEditor />);
+
+declare global {
+  interface Window {
+    contentInjected: boolean | undefined;
+  }
+}
+
+/**
+ * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * To overcome this we will check if the content is injected before rendering the editor
+ */
+const contentInjected = () => window.contentInjected;
+let interval: NodeJS.Timeout;
+interval = setInterval(() => {
+  if (!contentInjected()) return;
+  // Once content is injected into the webview, we can render the editor
+  const container = document.getElementById('root');
+  const root = createRoot(container!);
+  root.render(<AdvancedEditor />);
+  clearInterval(interval);
+  return;
+}, 1);

--- a/example/src/Examples/Advanced/editor-web/index.tsx
+++ b/example/src/Examples/Advanced/editor-web/index.tsx
@@ -13,7 +13,8 @@ declare global {
 }
 
 /**
- * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * On android - react-native-webview there is a bug where sometimes the content
+ * is injected after the window is loaded https://github.com/react-native-webview/react-native-webview/pull/2960
  * To overcome this we will check if the content is injected before rendering the editor
  */
 const contentInjected = () => window.contentInjected;

--- a/src/RichText/utils.ts
+++ b/src/RichText/utils.ts
@@ -67,6 +67,7 @@ export const getInjectedJSBeforeContentLoad = (editor: EditorBridge) => {
   }
     window.editable = ${editor.editable};
     window.dynamicHeight = ${editor.dynamicHeight};
+    window.contentInjected = true;
   `);
 };
 

--- a/src/simpleWebEditor/index.tsx
+++ b/src/simpleWebEditor/index.tsx
@@ -2,7 +2,24 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import Tiptap from './Tiptap';
 
-// check
-const container = document.getElementById('root');
-const root = createRoot(container!);
-root.render(<Tiptap />);
+declare global {
+  interface Window {
+    contentInjected: boolean | undefined;
+  }
+}
+
+/**
+ * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * To overcome this we will check if the content is injected before rendering the editor
+ */
+const contentInjected = () => window.contentInjected;
+let interval: NodeJS.Timeout;
+interval = setInterval(() => {
+  if (!contentInjected()) return;
+  // Once content is injected into the webview, we can render the editor
+  const container = document.getElementById('root');
+  const root = createRoot(container!);
+  root.render(<Tiptap />);
+  clearInterval(interval);
+  return;
+}, 1);

--- a/src/simpleWebEditor/index.tsx
+++ b/src/simpleWebEditor/index.tsx
@@ -9,7 +9,8 @@ declare global {
 }
 
 /**
- * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * On android - react-native-webview there is a bug where sometimes the content
+ * is injected after the window is loaded https://github.com/react-native-webview/react-native-webview/pull/2960
  * To overcome this we will check if the content is injected before rendering the editor
  */
 const contentInjected = () => window.contentInjected;

--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -1,5 +1,5 @@
 import debounce from 'lodash/debounce';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useEditor } from '@tiptap/react';
 import { Editor } from '@tiptap/core';
 import { type EditorMessage, EditorMessageType } from '../types/Messaging';
@@ -31,14 +31,17 @@ interface useTenTapArgs {
   bridges?: BridgeExtension[];
 }
 
-const extensionConfigs = JSON.parse(window.bridgeExtensionConfigMap || '{}');
-
 // Wrapper for tiptap editor that will add specific mobile functionality and support tentap bridges
 // args:
 // tiptapOptions - all the options that tiptap editor accepts
 // bridges - array of bridges that will be used to extend the editor
 export const useTenTap = (options?: useTenTapArgs) => {
   const { tiptapOptions = {}, bridges = [] } = options || {};
+  const extensionConfigs = useMemo(
+    () => JSON.parse(window.bridgeExtensionConfigMap || '{}'),
+    []
+  );
+
   function filterExists<T>(object: T): object is NonNullable<T> {
     return object !== null && object !== undefined;
   }

--- a/website/docs/setup/advancedSetup.md
+++ b/website/docs/setup/advancedSetup.md
@@ -121,9 +121,28 @@ import { AdvancedEditor } from './AdvancedEditor';
 /**
  * This is the entrypoint for the "web" part of our editor that will be built with vite
  */
-const container = document.getElementById('root');
-const root = createRoot(container!);
-root.render(<AdvancedEditor />);
+
+declare global {
+  interface Window {
+    contentInjected: boolean | undefined;
+  }
+}
+
+/**
+ * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * To overcome this we will check if the content is injected before rendering the editor
+ */
+const contentInjected = () => window.contentInjected;
+let interval: NodeJS.Timeout;
+interval = setInterval(() => {
+  if (!contentInjected()) return;
+  // Once content is injected into the webview, we can render the editor
+  const container = document.getElementById('root');
+  const root = createRoot(container!);
+  root.render(<AdvancedEditor />);
+  clearInterval(interval);
+  return;
+}, 1);
 ```
 
 ### Step 5 - adding a bundler

--- a/website/docs/setup/advancedSetup.md
+++ b/website/docs/setup/advancedSetup.md
@@ -129,7 +129,8 @@ declare global {
 }
 
 /**
- * On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
+ * On android - react-native-webview there is a bug where sometimes the content
+ * is injected after the window is loaded https://github.com/react-native-webview/react-native-webview/pull/2960
  * To overcome this we will check if the content is injected before rendering the editor
  */
 const contentInjected = () => window.contentInjected;


### PR DESCRIPTION
Fix for: https://github.com/10play/10tap-editor/issues/133

On android - react-native-webview there is a bug where sometimes the content is injected https://github.com/react-native-webview/react-native-webview/pull/2960
To overcome this we will check if the content is injected before rendering the editor