### PR TITLE
fix: add active icon styling to link icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@10play/tentap-editor",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "React Native Rich Text Editor",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/RichText/Toolbar/EditLinkBar.tsx
+++ b/src/RichText/Toolbar/EditLinkBar.tsx
@@ -33,7 +33,7 @@ export const EditLinkBar = ({
         >
           <Image
             source={Images.link}
-            style={[theme.toolbar.icon]}
+            style={[theme.toolbar.icon, theme.toolbar.iconActive]}
             resizeMode="contain"
           />
         </View>


### PR DESCRIPTION
Link bar link button container has active styling but the icon itself lacked the active styling. 
This PR adds the active styling to the link button in `EditLinkBar.tsx`