### PR TITLE
fix: vite config for web editor utils

### DIFF
--- a/src/webEditorUtils/vite.config.ts
+++ b/src/webEditorUtils/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['@tiptap/pm/view', 'react', 'react/jsx-runtime', 'react-dom'],
+      external: ['react', 'react/jsx-runtime', 'react-dom'],
       output: {
         dir: 'lib-web',
         // Provide global variables to use in the UMD build


### PR DESCRIPTION
Fix for https://github.com/10play/10tap-editor/issues/167

Remove `@tiptap/pm/view` from external - seems to be causing issues with the pro mentions example

This was added to fix some prosemirror decoration issues, we'll need to find a new way to solve that https://github.com/ueberdosis/tiptap/issues/3869#issuecomment-2167931620