### PR TITLE
fix: override highlight selection background on darkmode

### DIFF
--- a/src/RichText/theme.ts
+++ b/src/RichText/theme.ts
@@ -33,4 +33,7 @@ export const darkEditorCss = `
     border-left: 3px solid #babaca;
     padding-left: 1rem;
   }
+  .highlight-background {
+    background-color: #474749;
+  }
 `;

--- a/src/bridges/HighlightSelection.ts
+++ b/src/bridges/HighlightSelection.ts
@@ -23,7 +23,7 @@ export const blueBackgroundPlugin = Extension.create({
               const { from, to } = tr.selection;
               decorations.push(
                 Decoration.inline(from, to, {
-                  style: 'background-color: #e6e6ff;',
+                  class: 'highlight-background',
                 })
               );
               return DecorationSet.create(newEditorState.doc, decorations);

--- a/src/simpleWebEditor/index.html
+++ b/src/simpleWebEditor/index.html
@@ -32,6 +32,9 @@
     .ProseMirror:focus {
       outline: none;
     }
+    .highlight-background {
+      background-color: #e6e6ff;
+    }
   </style>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
We added on iOS `HighlightSelection.ts` so when the user edit link and the editor is not on focus anymore he still be aware to his selection,

1.
![image](https://github.com/user-attachments/assets/399ba83d-8007-4210-89bc-20768b50cdf2)

2.
![image](https://github.com/user-attachments/assets/7cbc37ff-7e64-4df4-a32a-eea0bab08154)


The problem is that in dark mode we keep the same light blue which causes the selection to be unreadable:
![image](https://github.com/user-attachments/assets/4d750d1a-827d-42ad-91ff-a0dde10b9088)



Related issues:

https://github.com/10play/10tap-editor/issues/180
https://github.com/10play/10tap-editor/issues/166
https://github.com/10play/10tap-editor/issues/144