### PR TITLE
fix: ios double click zoom

### DIFF
--- a/example/src/Examples/Advanced/editor-web/index.html
+++ b/example/src/Examples/Advanced/editor-web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>RichTextEditor</title>
   </head>
   <style>

--- a/src/simpleWebEditor/index.html
+++ b/src/simpleWebEditor/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>RichTextEditor</title>
   </head>
   <style>

--- a/website/docs/setup/advancedSetup.md
+++ b/website/docs/setup/advancedSetup.md
@@ -60,7 +60,10 @@ Add the following files
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>RichTextEditor</title>
   </head>
   <style>


### PR DESCRIPTION
Add meta tag to disable use scale - this fixes an issue where focusing the editor causes text to seem bigger #222