### PR TITLE
Added hintText option to add link text

### DIFF
--- a/src/RichText/Toolbar/EditLinkBar.tsx
+++ b/src/RichText/Toolbar/EditLinkBar.tsx
@@ -9,7 +9,9 @@ interface EditLinkBarProps {
   onEditLink: (newLink: string) => void;
   onLinkIconClick: () => void;
   initialLink: string | undefined;
+  hintText?: string;
 }
+
 
 export const EditLinkBar = ({
   theme,
@@ -54,7 +56,7 @@ export const EditLinkBar = ({
           onEditLink(link);
         }}
       >
-        <Text style={theme.toolbar.linkBarTheme.doneButtonText}>Insert</Text>
+        <Text style={theme.toolbar.linkBarTheme.doneButtonText}>{hintText || "Insert"}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/src/RichText/Toolbar/Toolbar.tsx
+++ b/src/RichText/Toolbar/Toolbar.tsx
@@ -95,6 +95,7 @@ export function Toolbar({
             setToolbarContext(ToolbarContext.Main);
             editor.focus();
           }}
+          hintText={editor.theme.toolbar.linkBarTheme.hintText}
           onEditLink={(link) => {
             editor.setLink(link);
             editor.focus();


### PR DESCRIPTION
This PR adds small feature to be able to change the text in the `EditLinkBar` via theme props.

Example usage

```
  const editor = useEditorBridge({
    theme: {
      toolbar: {
        linkBarTheme: {
          hintText: "Apply", // Changes from Insert to Apply
        },
      },
    },
  });
```
