### PR TITLE
fix: dynamic height jitter android

### DIFF
--- a/src/RichText/utils.ts
+++ b/src/RichText/utils.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import type BridgeExtension from '../bridges/base';
 import type { EditorBridge } from '../types';
 
@@ -70,6 +71,7 @@ export const getInjectedJSBeforeContentLoad = (editor: EditorBridge) => {
     window.disableColorHighlight = ${!!editor.disableColorHighlight};
     window.dynamicHeight = ${editor.dynamicHeight};
     window.contentInjected = true;
+    window.platform = "${Platform.OS}";
   `);
 };
 

--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -149,7 +149,6 @@ export const useTenTap = (options?: useTenTapArgs) => {
               payload: height + paragraphHeight,
             });
           }
-          // document.body.style.overflow = 'hidden';
           sendMessage({
             type: CoreEditorActionType.DocumentHeight,
             payload: height,

--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -16,6 +16,7 @@ declare global {
     whiteListBridgeExtensions: string[];
     dynamicHeight?: boolean;
     disableColorHighlight?: boolean;
+    platform?: 'ios' | 'android' | 'web';
     ReactNativeWebView: { postMessage: (message: string) => void };
   }
 }
@@ -135,17 +136,33 @@ export const useTenTap = (options?: useTenTapArgs) => {
   }, [editor, bridges]);
 
   useEffect(() => {
-    if (editor && !contentHeightListener.connected && window.dynamicHeight)
+    if (editor && !contentHeightListener.connected && window.dynamicHeight) {
+      const paragraphHeight = getParagraphHeight();
       contentHeightListener.connect(
         document.querySelector('.ProseMirror')!,
         (height) => {
           sendMessage({
             type: CoreEditorActionType.DocumentHeight,
-            payload: height,
+            payload: height + paragraphHeight,
           });
         }
       );
+    }
   }, [editor]);
 
   return editor;
+};
+
+// This is a utility to get the height of a paragraph element
+// This is needed on android to avoid an issue where text jumps https://github.com/10play/10tap-editor/issues/236
+const getParagraphHeight = () => {
+  if (window.platform !== 'android') return 0;
+  const tempParagraph = document.createElement('p');
+  tempParagraph.style.visibility = 'hidden'; // Ensure it's not visible
+  tempParagraph.textContent = 'tmp';
+  document.body.appendChild(tempParagraph);
+
+  const pHeight = tempParagraph.getBoundingClientRect().height;
+  document.body.removeChild(tempParagraph);
+  return pHeight;
 };

--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -141,9 +141,18 @@ export const useTenTap = (options?: useTenTapArgs) => {
       contentHeightListener.connect(
         document.querySelector('.ProseMirror')!,
         (height) => {
+          // On android we first need to send the height of the document + paragraph height
+          // to avoid an issue where text jumps https://github.com/10play/10tap-editor/issues/236
+          if (window.platform === 'android') {
+            sendMessage({
+              type: CoreEditorActionType.DocumentHeight,
+              payload: height + paragraphHeight,
+            });
+          }
+          // document.body.style.overflow = 'hidden';
           sendMessage({
             type: CoreEditorActionType.DocumentHeight,
-            payload: height + paragraphHeight,
+            payload: height,
           });
         }
       );
@@ -153,8 +162,6 @@ export const useTenTap = (options?: useTenTapArgs) => {
   return editor;
 };
 
-// This is a utility to get the height of a paragraph element
-// This is needed on android to avoid an issue where text jumps https://github.com/10play/10tap-editor/issues/236
 const getParagraphHeight = () => {
   if (window.platform !== 'android') return 0;
   const tempParagraph = document.createElement('p');


### PR DESCRIPTION
Fix jitter mentioned in https://github.com/10play/10tap-editor/issues/236 by adding paragraph height to total added height