### PR TITLE
Let onMessage handlers coexist

### DIFF
--- a/src/RichText/RichText.tsx
+++ b/src/RichText/RichText.tsx
@@ -17,6 +17,11 @@ import { CoreEditorActionType } from '../bridges/core';
 
 interface RichTextProps extends WebViewProps {
   editor: EditorBridge;
+
+  /** Makes it so that the onMessage method provided by Tentap does not fire if you have your own custom onMessage method.
+   * Introduced for backwards compatibility with previous versions of Tentap that had this behaviour by default.
+   * */
+  exclusivelyUseCustomOnMessage?: boolean;
 }
 
 const styles = StyleSheet.create({
@@ -36,7 +41,12 @@ const DEV_SERVER_URL = 'http://localhost:3000';
 // TODO: make it a prop
 const TOOLBAR_HEIGHT = 44;
 
-export const RichText = ({ editor, ...props }: RichTextProps) => {
+export const RichText = ({
+  editor,
+  onMessage,
+  exclusivelyUseCustomOnMessage = true,
+  ...props
+}: RichTextProps) => {
   const [editorHeight, setEditorHeight] = useState(0);
   const [key, setKey] = useState('webview');
   const [loaded, setLoaded] = useState(isFabric());
@@ -49,6 +59,9 @@ export const RichText = ({ editor, ...props }: RichTextProps) => {
       };
 
   const onWebviewMessage = (event: WebViewMessageEvent) => {
+    onMessage && onMessage(event);
+    if (exclusivelyUseCustomOnMessage && onMessage) return;
+
     const { data } = event.nativeEvent;
     // on expo-web we sometimes get react-dev messages that come in as objects - so we ignore these
     if (typeof data !== 'string') return;

--- a/website/docs/api/Components.md
+++ b/website/docs/api/Components.md
@@ -10,9 +10,10 @@ a components that wraps the webview that renders the editor
 
 props:
 
-| name   | type           | default | description                                                             |
-| ------ | -------------- | ------- | ----------------------------------------------------------------------- |
-| editor | `EditorBridge` |         | The bridge instance that created with [useEditorBridge](./EditorBridge) |
+| name                          | type           | default | description                                                                                                                                                  |
+| ----------------------------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| editor                        | `EditorBridge` |         | The bridge instance that created with [useEditorBridge](./EditorBridge)                                                                                      |
+| exclusivelyUseCustomOnMessage | `boolean`      | true    | When true, if you pass an `onMessage` prop (webview) this will override tentap's own `onMessage` property. You probably want to disable this, it's here for compatibility. |
 
 you can also override any of the regular [WebView props](https://github.com/react-native-webview/react-native-webview/blob/HEAD/docs/Reference.md) <i>although this is not recommended</i>
 


### PR DESCRIPTION
The current behaviour we have here is that if you pass your own onMessage handler, it will override the existing TenTap one, which is, I think, not the intended behaviour in most cases. 

Therefore I just introduced another prop that makes this possible, while maintaining the original behaviour. Basically, if you use onMessage right now through tentap, and you upgrade to this version, nothing changes. 