### PR TITLE
Fix `initialContent` not working consistently on Android

### DIFF
--- a/src/webEditorUtils/useTenTap.tsx
+++ b/src/webEditorUtils/useTenTap.tsx
@@ -21,8 +21,6 @@ declare global {
   }
 }
 
-const content = window.initialContent || '';
-
 export const sendMessage = (message: EditorMessage) => {
   // @ts-ignore TODO fix type
   window.ReactNativeWebView?.postMessage(JSON.stringify(message));
@@ -80,6 +78,8 @@ export const useTenTap = (options?: useTenTapArgs) => {
       payload: state,
     });
   }, 10);
+
+  const content = window.initialContent || '';
 
   const editor = useEditor({
     content,


### PR DESCRIPTION
As observed in https://github.com/10play/10tap-editor/blob/fca4b93169955c76fd028710076d30c25270935d/src/simpleWebEditor/index.tsx#L11-L16, there is a bug where sometimes the content is injected after the window is loaded on Android.

Although a `setInterval` check for `contentInjected` exists in `simpleWebEditor/index.tsx`, the problem arises because `window.initialContent` is evaluated immediately inside `useTenTap.tsx`. This causes `initialContent` to resolve to an empty string when the content injection occurs post-window load.

This PR modifies the `useTenTap` hook to evaluate `window.initialContent` inside the hook, ensuring content is set properly, even if it is injected later.