### PR TITLE
feat: add "empty" boolean to bridge state

### DIFF
--- a/src/bridges/core.ts
+++ b/src/bridges/core.ts
@@ -14,6 +14,7 @@ type CoreEditorState = {
   isFocused: boolean;
   isReady: boolean;
   editable: boolean;
+  empty: boolean;
 };
 
 type FocusArgs = 'start' | 'end' | 'all' | number | boolean | null;
@@ -354,6 +355,7 @@ export const CoreBridge = new BridgeExtension<
         to: editor.state.selection.to,
       },
       editable: editor.isEditable,
+      empty: editor.isEmpty,
     };
   },
 });

--- a/website/docs/api/BridgeState.md
+++ b/website/docs/api/BridgeState.md
@@ -15,6 +15,11 @@ The list above is the interface of BridgeState in case you use `TenTapStarterkit
 `boolean`
 <br />Is the editor editable or not <br /> extended by [CoreBridge](./BridgeExtensions#coreextension)
 
+#### empty
+
+`boolean`
+<br />Is the editor empty or not <br /> extended by [CoreBridge](./BridgeExtensions#coreextension)
+
 #### selection
 
 `{ from: number; to: number }`


### PR DESCRIPTION
Previously there was no way to tell, from the RN side, if the editor is empty or not. With this change we can now do things such as enable/disable the submit button based on if the editor is empty.


Example:

```tsx
function MyComponent() {
  const editor = useEditorBridge(...);
  const editorState = useBridgeState(editor);
  
  return (
    <View>
      ...
      <Button disabled={editorState.empty}>Submit</Button>
    </View>
  );
}
```
