### PR TITLE
fix: add ios.componentProvider to codegenConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,12 @@
   "codegenConfig": {
     "name": "RNTenTapViewSpec",
     "type": "components",
-    "jsSrcsDir": "src"
+    "jsSrcsDir": "src",
+    "ios": {
+      "componentProvider": {
+        "TenTapView": "TenTapView"
+      }
+    }
   },
   "dependencies": {
     "@tiptap/extension-blockquote": "^2.2.1",


### PR DESCRIPTION
## Description
- Fix deprecation warning by adding missing `ios.componentProvider` [configuration](https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen).

## Problem
- When using `@10play/tentap-editor`, the following deprecation warning appears:

```
[DEPRECATED] @10play/tentap-editor should add the 'ios.componentProvider' property in their codegenConfig
```
<img width="597" alt="image" src="https://github.com/user-attachments/assets/da541ab5-f6fd-4750-ad0c-098fafd7dbfe" />

This maps the JavaScript TenTapView component to the iOS native TenTapView class for proper codegen support.

## Testing
- react-native v0.79.2, expo sdk 53
- Verified warning no longer appears
