### PR TITLE
Fix package.json to include index.tsx instead of index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/src/index.d.ts",
-  "react-native": "src/index.js",
+  "react-native": "src/index.tsx",
   "exports": {
     ".": {
       "import": "./lib/module/index.js",


### PR DESCRIPTION
Fixes naming error in package.json that's causing build errors on Metro:

```
Metro has encountered an error: While trying to resolve module*@10play/tentap-editor' from file, the
package *xx/node_modules/ @10play/tentap-editor/package.json was successfully found. However, this package itself specifies a 'main' module field that could not be resolved ('xx/node_modules/@10play/tentap-editor/src/index.js'
. Indeed, none of these files exist:
```
![indexjserror](https://github.com/user-attachments/assets/27ed52b0-7037-4ab2-96bd-ac856d8b3340)

index.js should be index.tsx. The error was introduced in this PR: https://github.com/10play/10tap-editor/pull/303/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R8