### PR TITLE
fix: embed init vars in HTML to fix Fabric race condition

### DIFF
--- a/src/RichText/RichText.tsx
+++ b/src/RichText/RichText.tsx
@@ -12,7 +12,6 @@ import { type EditorMessage } from '../types/Messaging';
 import { useKeyboard } from '../utils';
 import type { EditorBridge } from '../types';
 import { getInjectedJS, getInjectedJSBeforeContentLoad } from './utils';
-import { isFabric } from '../utils/misc';
 import { CoreEditorActionType } from '../bridges/core';
 
 interface RichTextProps extends WebViewProps {
@@ -48,15 +47,18 @@ export const RichText = ({
   ...props
 }: RichTextProps) => {
   const [editorHeight, setEditorHeight] = useState(0);
-  const [key, setKey] = useState('webview');
-  const [loaded, setLoaded] = useState(isFabric());
   const { keyboardHeight, isKeyboardUp } = useKeyboard();
-  const source: WebViewProps['source'] = editor.DEV
-    ? { uri: editor.DEV_SERVER_URL || DEV_SERVER_URL }
-    : {
-        html: editor.customSource || editorHtml,
-        baseUrl: editor.webviewBaseURL,
-      };
+
+  // Embed init variables directly in the HTML as an inline <script> to avoid
+  // the Fabric race condition where injectedJavaScriptBeforeContentLoaded
+  // may not execute before the WebView HTML loads.
+  // See https://github.com/10play/10tap-editor/issues/343
+  const sourceHtml = useMemo(() => {
+    if (editor.DEV) return undefined;
+    const baseHtml = editor.customSource || editorHtml;
+    const initJS = getInjectedJSBeforeContentLoad(editor);
+    return baseHtml.replace('<body>', `<body>\n<script>${initJS}</script>`);
+  }, [editor]);
 
   const onWebviewMessage = (event: WebViewMessageEvent) => {
     onMessage && onMessage(event);
@@ -124,17 +126,16 @@ export const RichText = ({
       )}
       <WebView
         scrollEnabled={false}
-        key={key}
-        style={[
-          RichTextStyles.fullScreen,
-          { display: loaded ? 'flex' : 'none' },
-          editor.theme.webview,
-        ]}
+        style={[RichTextStyles.fullScreen, editor.theme.webview]}
         containerStyle={[
           editor.theme.webviewContainer,
           { height: editor.dynamicHeight ? editorHeight : undefined },
         ]}
-        source={source}
+        source={
+          editor.DEV
+            ? { uri: editor.DEV_SERVER_URL || DEV_SERVER_URL }
+            : { html: sourceHtml!, baseUrl: editor.webviewBaseURL }
+        }
         injectedJavaScript={injectedJavaScript}
         injectedJavaScriptBeforeContentLoaded={getInjectedJSBeforeContentLoad(
           editor
@@ -145,16 +146,6 @@ export const RichText = ({
         webviewDebuggingEnabled={__DEV__}
         keyboardDisplayRequiresUserAction={false}
         {...props}
-        // Propagated Props
-        onLoad={(e) => {
-          setLoaded(true);
-          // This is a workaround for iOS to make sure the webview is loaded
-          // See https://github.com/react-native-webview/react-native-webview/issues/3578
-          if (Platform.OS === 'ios' && key === 'webview') {
-            setKey('webview_reloaded');
-          }
-          props.onLoad && props.onLoad(e);
-        }}
       />
     </>
   );


### PR DESCRIPTION
## Problem

On Fabric (New Architecture), `injectedJavaScriptBeforeContentLoaded` may not execute before the WebView HTML loads (#343). The initialization chain is:

1. `injectedJavaScriptBeforeContentLoaded` sets `window.contentInjected = true` + bridge config vars
2. The HTML's bundled JS polls `window.contentInjected` via `setInterval(..., 1)` before rendering TipTap
3. On Fabric, the `source` prop (HTML) may be applied to WKWebView **before** the injected script runs
4. Result: `window.contentInjected` is never set → TipTap never renders → stuck spinner

## Fix

Instead of relying on `injectedJavaScriptBeforeContentLoaded` (which races with HTML loading), embed the initialization variables as an inline `<script>` tag directly in the HTML string via `useMemo`. Inline scripts in the HTML execute synchronously during parsing, **before** any `<script type="module">` or deferred scripts. This eliminates the race condition entirely.

```tsx
const sourceHtml = useMemo(() => {
  if (editor.DEV) return undefined;
  const baseHtml = editor.customSource || editorHtml;
  const initJS = getInjectedJSBeforeContentLoad(editor);
  return baseHtml.replace('<body>', `<body>\n<script>${initJS}</script>`);
}, [editor]);
```

`injectedJavaScriptBeforeContentLoaded` is kept as a harmless belt-and-suspenders fallback (and is still needed for the DEV server case where we can't modify the HTML).

Also removes the obsolete iOS WebView remount hack (`setKey('webview_reloaded')`) that worked around [react-native-webview#3578](https://github.com/react-native-webview/react-native-webview/issues/3578), fixed in 13.12.5.

## Changes

Only `src/RichText/RichText.tsx` — 1 file changed, 17 insertions, 26 deletions. No build artifacts or other files touched.

Fixes #343