### PR TITLE
docs: update pro plans link to /products

### DIFF
--- a/website/docs/examples/comments.md
+++ b/website/docs/examples/comments.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/docs/examples/fonts.md
+++ b/website/docs/examples/fonts.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/docs/examples/mentions.md
+++ b/website/docs/examples/mentions.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/docs/examples/realtimeCollab.md
+++ b/website/docs/examples/realtimeCollab.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/docs/examples/search.md
+++ b/website/docs/examples/search.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-1.0/examples/comments.md
+++ b/website/versioned_docs/version-1.0/examples/comments.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-1.0/examples/fonts.md
+++ b/website/versioned_docs/version-1.0/examples/fonts.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-1.0/examples/mentions.md
+++ b/website/versioned_docs/version-1.0/examples/mentions.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-1.0/examples/realtimeCollab.md
+++ b/website/versioned_docs/version-1.0/examples/realtimeCollab.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-1.0/examples/search.md
+++ b/website/versioned_docs/version-1.0/examples/search.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-pre-1.0/examples/comments.md
+++ b/website/versioned_docs/version-pre-1.0/examples/comments.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-pre-1.0/examples/fonts.md
+++ b/website/versioned_docs/version-pre-1.0/examples/fonts.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-pre-1.0/examples/mentions.md
+++ b/website/versioned_docs/version-pre-1.0/examples/mentions.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-pre-1.0/examples/realtimeCollab.md
+++ b/website/versioned_docs/version-pre-1.0/examples/realtimeCollab.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 

--- a/website/versioned_docs/version-pre-1.0/examples/search.md
+++ b/website/versioned_docs/version-pre-1.0/examples/search.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 :::info
 
-This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev#10tap-pricing">See plans</a>
+This is a Pro example. Get all pro examples, 1:1 support from the 10tap team, prioritized Github issues and keep 10tap under an MIT License with a 10tap Pro subscription. <a href="https://10play.dev/products">See plans</a>
 
 :::
 


### PR DESCRIPTION
## Summary

The "See plans" link in the Pro example callouts pointed at `https://10play.dev#10tap-pricing`, an anchor that no longer resolves. Updated it to `https://10play.dev/products`.

Applied across all 15 occurrences: current docs plus the `version-1.0` and `version-pre-1.0` versioned docs (comments, fonts, mentions, realtimeCollab, search).

## Test plan

- [x] `grep -rn "10tap-pricing"` returns no remaining matches
- Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)